### PR TITLE
add test's persistence cleanup for single thread performance check

### DIFF
--- a/src/test/java/assessment/parkinglot/ParkingLotServiceApplicationTests.java
+++ b/src/test/java/assessment/parkinglot/ParkingLotServiceApplicationTests.java
@@ -1,25 +1,37 @@
 package assessment.parkinglot;
 
 import assessment.parkinglot.config.AppConfigurationProperties;
+import assessment.parkinglot.config.AppTestConfig;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@ContextConfiguration(classes = { ParkingLotServiceApplication.class, AppTestConfig.class })
 @Profile("test")
 @ActiveProfiles({"test"})
 public class ParkingLotServiceApplicationTests {
 
 	private final AppConfigurationProperties appConfigurationProperties;
+	private final PersistenceCleanerService persistenceCleanerService;
 
 	@Autowired
-    public ParkingLotServiceApplicationTests(AppConfigurationProperties appConfigurationProperties) {
+    public ParkingLotServiceApplicationTests(AppConfigurationProperties appConfigurationProperties, PersistenceCleanerService persistenceCleanerService) {
         this.appConfigurationProperties = appConfigurationProperties;
+        this.persistenceCleanerService = persistenceCleanerService;
     }
+
+	@BeforeEach
+	void beforeAll(){
+		this.persistenceCleanerService.cleanup("PUBLIC");
+	}
 
     @Test
 	void contextLoads() {

--- a/src/test/java/assessment/parkinglot/config/AppTestConfig.java
+++ b/src/test/java/assessment/parkinglot/config/AppTestConfig.java
@@ -1,0 +1,47 @@
+package assessment.parkinglot.config;
+
+import assessment.parkinglot.config.components.PersistenceCleanerService;
+import assessment.parkinglot.config.components.PersistenceCleanerServiceByRepository;
+import assessment.parkinglot.config.components.PersistenceCleanerServiceByTruncation;
+import assessment.parkinglot.peristence.repositories.SpotRepository;
+import assessment.parkinglot.peristence.repositories.SpotTypeRepository;
+import assessment.parkinglot.peristence.repositories.ValidSpotTypeByVehicleTypeRepository;
+import assessment.parkinglot.peristence.repositories.VehicleTypeRepository;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class AppTestConfig {
+
+    @Bean
+    public PersistenceCleanerService getPersistenceCleaner(
+            EntityManager entityManager
+            , SpotRepository spotRepository
+            , SpotTypeRepository spotTypeRepository
+            , ValidSpotTypeByVehicleTypeRepository validSpotTypeByVehicleTypeRepository
+            , VehicleTypeRepository vehicleTypeRepository
+    ){
+        // Simple persistence cleaner switcher to compare performance
+        var truncaton=false;
+
+        if(truncaton) {
+            return this.getPersistenceCleanerByTruncation(entityManager);
+        }else {
+            return this.getPersistenceCleanerServiceByRepository(spotRepository, spotTypeRepository, validSpotTypeByVehicleTypeRepository, vehicleTypeRepository);
+        }
+    }
+
+    private PersistenceCleanerServiceByRepository getPersistenceCleanerServiceByRepository(SpotRepository spotRepository, SpotTypeRepository spotTypeRepository, ValidSpotTypeByVehicleTypeRepository validSpotTypeByVehicleTypeRepository, VehicleTypeRepository vehicleTypeRepository) {
+        return new PersistenceCleanerServiceByRepository(
+                spotRepository
+                , spotTypeRepository
+                , validSpotTypeByVehicleTypeRepository
+                , vehicleTypeRepository
+        );
+    }
+
+    private PersistenceCleanerServiceByTruncation getPersistenceCleanerByTruncation(EntityManager entityManager) {
+        return new PersistenceCleanerServiceByTruncation(entityManager);
+    }
+}

--- a/src/test/java/assessment/parkinglot/config/components/PersistenceCleanerService.java
+++ b/src/test/java/assessment/parkinglot/config/components/PersistenceCleanerService.java
@@ -1,0 +1,6 @@
+package assessment.parkinglot.config.components;
+
+public interface PersistenceCleanerService {
+    public void cleanup(String schemaName);
+
+}

--- a/src/test/java/assessment/parkinglot/config/components/PersistenceCleanerServiceByRepository.java
+++ b/src/test/java/assessment/parkinglot/config/components/PersistenceCleanerServiceByRepository.java
@@ -1,0 +1,50 @@
+package assessment.parkinglot.config.components;
+
+import assessment.parkinglot.peristence.repositories.SpotRepository;
+import assessment.parkinglot.peristence.repositories.SpotTypeRepository;
+import assessment.parkinglot.peristence.repositories.ValidSpotTypeByVehicleTypeRepository;
+import assessment.parkinglot.peristence.repositories.VehicleTypeRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PersistenceCleanerServiceByRepository implements PersistenceCleanerService {
+    private final SpotRepository spotRepository;
+    private final SpotTypeRepository spotTypeRepository;
+    private final ValidSpotTypeByVehicleTypeRepository validSpotTypeByVehicleTypeRepository;
+    private final VehicleTypeRepository vehicleTypeRepository;
+    private final Logger logger= LoggerFactory.getLogger(PersistenceCleanerServiceByRepository.class);
+
+    public PersistenceCleanerServiceByRepository(
+            SpotRepository spotRepository
+            , SpotTypeRepository spotTypeRepository
+            , ValidSpotTypeByVehicleTypeRepository validSpotTypeByVehicleTypeRepository
+            , VehicleTypeRepository vehicleTypeRepository
+    ) {
+        this.spotRepository = spotRepository;
+        this.spotTypeRepository = spotTypeRepository;
+        this.validSpotTypeByVehicleTypeRepository = validSpotTypeByVehicleTypeRepository;
+        this.vehicleTypeRepository = vehicleTypeRepository;
+    }
+
+    public void cleanup(String schemaName) {
+        this.disableConstraints();
+        this.truncateTables(schemaName);
+        this.resetSequences(schemaName);
+        this.enableConstraints();
+    }
+
+    private void disableConstraints() {
+    }
+    private void enableConstraints() {
+    }
+
+    private void truncateTables(String schemaName) {
+        this.spotRepository.deleteAll();
+        this.validSpotTypeByVehicleTypeRepository.deleteAll();
+        this.spotTypeRepository.deleteAll();
+        this.vehicleTypeRepository.deleteAll();
+    }
+    private void resetSequences(String schemaName) {
+    }
+
+}

--- a/src/test/java/assessment/parkinglot/config/components/PersistenceCleanerServiceByTruncation.java
+++ b/src/test/java/assessment/parkinglot/config/components/PersistenceCleanerServiceByTruncation.java
@@ -1,0 +1,79 @@
+package assessment.parkinglot.config.components;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class PersistenceCleanerServiceByTruncation implements PersistenceCleanerService {
+    private final EntityManager entityManager;
+    private final Logger logger= LoggerFactory.getLogger(PersistenceCleanerServiceByTruncation.class);
+
+    public PersistenceCleanerServiceByTruncation(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public void cleanup(String schemaName) {
+        this.disableConstraints();
+        this.truncateTables(schemaName);
+        this.resetSequences(schemaName);
+        this.enableConstraints();
+    }
+
+    private void disableConstraints() {
+        var sql="SET REFERENTIAL_INTEGRITY FALSE";
+        var query=this.entityManager.createNativeQuery(sql, String.class);
+        query.executeUpdate();
+    }
+    private void enableConstraints() {
+        var sql="SET REFERENTIAL_INTEGRITY TRUE";
+        var query=this.entityManager.createNativeQuery(sql, String.class);
+        query.executeUpdate();
+    }
+
+    private void truncateTables(String schemaName) {
+        getSchemaTables(schemaName).forEach(tableName ->{
+            var sql=String.format("TRUNCATE TABLE %s RESTART IDENTITY", tableName);
+            var query=this.entityManager.createNativeQuery(sql, String.class);
+            query.executeUpdate();
+            logger.info(String.format("Table %s truncated.",tableName));
+        });
+    }
+    private void resetSequences(String schemaName) {
+        getSchemaSequences(schemaName).forEach(sequenceName -> {
+            var sql=String.format("ALTER SEQUENCE %s RESTART WITH 1", sequenceName);
+            var query=this.entityManager.createNativeQuery(sql, String.class);
+            query.executeUpdate();
+            logger.info(String.format("Sequence %s truncated.",sequenceName));
+        });
+
+    }
+
+
+    private Set<String> getSchemaTables(String schemaName) {
+        String sql = String.format("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES  where TABLE_SCHEMA=:table_schema");
+        var query=this.entityManager.createNativeQuery(sql, String.class);
+        query.setParameter("table_schema", schemaName);
+        return queryForList(query);
+    }
+
+    private Set<String> getSchemaSequences(String schemaName) {
+        String sql = String.format("SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SEQUENCES WHERE SEQUENCE_SCHEMA=:table_schema", schemaName);
+        var query=this.entityManager.createNativeQuery(sql, String.class);
+        query.setParameter("table_schema", schemaName);
+        return queryForList(query);
+    }
+
+    private Set<String> queryForList(Query query) {
+        var rs=query.getResultList();
+        Set<String> tables = new HashSet<>(rs.size());
+        tables.addAll(rs);
+        return tables;
+    }
+
+}

--- a/src/test/java/assessment/parkinglot/integration/BasicIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/BasicIntegrationTest.java
@@ -1,35 +1,38 @@
 package assessment.parkinglot.integration;
 
 import assessment.parkinglot.ParkingLotServiceApplication;
+import assessment.parkinglot.config.AppTestConfig;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = { ParkingLotServiceApplication.class })
-@WebAppConfiguration(value = "")
+@SpringBootTest
+@ContextConfiguration(classes = { ParkingLotServiceApplication.class, AppTestConfig.class })
 @ActiveProfiles({"test"})
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public abstract class BasicIntegrationTest {
 
     final private WebApplicationContext webApplicationContext;
+    final private PersistenceCleanerService persistenceCleanerService;
     private MockMvc mockMvc;
 
-    public BasicIntegrationTest(WebApplicationContext webApplicationContext) {
+    public BasicIntegrationTest(
+            WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
+    ) {
         this.webApplicationContext = webApplicationContext;
+        this.persistenceCleanerService = persistenceCleanerService;
     }
 
     @BeforeEach
     public void setup() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext).build();
+        persistenceCleanerService.cleanup("PUBLIC");
     }
 
     @Test

--- a/src/test/java/assessment/parkinglot/integration/controller/BaseControllerPostMethodErrorsIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/BaseControllerPostMethodErrorsIntegrationTest.java
@@ -1,5 +1,6 @@
 package assessment.parkinglot.integration.controller;
 
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -15,9 +16,10 @@ public abstract class BaseControllerPostMethodErrorsIntegrationTest<T>
     final protected ObjectMapper mapper = new ObjectMapper();
     public BaseControllerPostMethodErrorsIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , Class<T> controller
     ) {
-        super(webApplicationContext, controller);
+        super(webApplicationContext, persistenceCleanerService, controller);
     }
 
     public abstract void badRequest_givenPostRequest_when_endpoint_validation_fails() throws Exception ;

--- a/src/test/java/assessment/parkinglot/integration/controller/BasicControllerIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/BasicControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package assessment.parkinglot.integration.controller;
 
 import assessment.parkinglot.integration.BasicIntegrationTest;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import jakarta.servlet.ServletContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockServletContext;
@@ -16,9 +17,13 @@ public abstract class BasicControllerIntegrationTest<T> extends BasicIntegration
 
     public BasicControllerIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , Class<T> expectedController
     ) {
-        super(webApplicationContext);
+        super(
+                webApplicationContext
+                , persistenceCleanerService
+        );
         this.expectedController = expectedController;
     }
 

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerDataInitializationHappyPathIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerDataInitializationHappyPathIntegrationTest.java
@@ -2,6 +2,7 @@ package assessment.parkinglot.integration.controller;
 
 import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.errors.DataDuplication;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.peristence.repositories.VehicleTypeRepository;
 import assessment.parkinglot.services.PersistenceService;
 import org.junit.jupiter.api.Test;
@@ -19,9 +20,11 @@ public class LotControllerDataInitializationHappyPathIntegrationTest
     @Autowired
     public LotControllerDataInitializationHappyPathIntegrationTest(
             WebApplicationContext webApplicationContext
-            , PersistenceService persistenceService, VehicleTypeRepository vehicleTypeRepository
+            , PersistenceCleanerService persistenceCleanerService
+            , PersistenceService persistenceService
+            , VehicleTypeRepository vehicleTypeRepository
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService, LotController.class);
         this.persistenceService = persistenceService;
         this.vehicleTypeRepository = vehicleTypeRepository;
     }

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerDepartingHappyPathIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerDepartingHappyPathIntegrationTest.java
@@ -4,6 +4,7 @@ import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.errors.DataDuplication;
 import assessment.parkinglot.errors.DataNotFound;
 import assessment.parkinglot.controller.model.DepartingRequest;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.peristence.repositories.SpotRepository;
 import assessment.parkinglot.services.PersistenceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,9 +28,11 @@ public class LotControllerDepartingHappyPathIntegrationTest
     @Autowired
     public LotControllerDepartingHappyPathIntegrationTest(
             WebApplicationContext webApplicationContext
-            , PersistenceService persistenceService, SpotRepository spotRepository
+            , PersistenceCleanerService persistenceCleanerService
+            , PersistenceService persistenceService
+            , SpotRepository spotRepository
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService, LotController.class);
         this.persistenceService = persistenceService;
         this.spotRepository = spotRepository;
     }
@@ -63,8 +66,8 @@ public class LotControllerDepartingHappyPathIntegrationTest
                 MockMvcResultMatchers.jsonPath("$.asOf").isNotEmpty()
         ).andExpect(
                 MockMvcResultMatchers.jsonPath("$.parkingId").value(departingRequest.parkingId())
-        ).andExpect(
-                MockMvcResultMatchers.jsonPath("$.slots[0]").value("1")
+       ).andExpect(
+                MockMvcResultMatchers.jsonPath("$.slots[0]").isNotEmpty()
         )
         ;
     }

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerDepartingPostMethodErrorsIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerDepartingPostMethodErrorsIntegrationTest.java
@@ -2,6 +2,7 @@ package assessment.parkinglot.integration.controller;
 
 import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.controller.model.DepartingRequest;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.WebApplicationContext;
@@ -14,9 +15,10 @@ public class LotControllerDepartingPostMethodErrorsIntegrationTest
     @Autowired
     public LotControllerDepartingPostMethodErrorsIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , LotController controller
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService, LotController.class);
     }
 
     @Test

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerParkingHappyPathIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerParkingHappyPathIntegrationTest.java
@@ -3,8 +3,10 @@ package assessment.parkinglot.integration.controller;
 import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.controller.model.ParkingRequest;
 import assessment.parkinglot.errors.DataDuplication;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.services.PersistenceService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,9 +26,10 @@ public class LotControllerParkingHappyPathIntegrationTest
     @Autowired
     public LotControllerParkingHappyPathIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , PersistenceService persistenceService
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService , LotController.class);
         this.persistenceService = persistenceService;
     }
 
@@ -55,7 +58,7 @@ public class LotControllerParkingHappyPathIntegrationTest
                 ).andExpect(
                         MockMvcResultMatchers.jsonPath("$.slots.size()").value("1")
                 ).andExpect(
-                        MockMvcResultMatchers.jsonPath("$.slots[0]").value("1")
+                        MockMvcResultMatchers.jsonPath("$.slots[0]").isNotEmpty()
                 )
                 .andReturn();
     }
@@ -85,11 +88,23 @@ public class LotControllerParkingHappyPathIntegrationTest
                 ).andExpect(
                         MockMvcResultMatchers.jsonPath("$.slots.size()").value("3")
                 ).andExpect(
-                        MockMvcResultMatchers.jsonPath("$.slots[0]").value("1")
+                        MockMvcResultMatchers.jsonPath("$.slots[0]").isNotEmpty()
                 ).andExpect(
-                        MockMvcResultMatchers.jsonPath("$.slots[1]").value("2")
+                        MockMvcResultMatchers.jsonPath("$.slots[1]").isNotEmpty()
                 ).andExpect(
-                        MockMvcResultMatchers.jsonPath("$.slots[2]").value("3")
+                        MockMvcResultMatchers.jsonPath("$.slots[2]").isNotEmpty()
+                ).andExpect(
+                        MockMvcResultMatchers.jsonPath("$.slots[0]").value(
+                                Matchers.not(MockMvcResultMatchers.jsonPath("$.slots[1]"))
+                        )
+                ).andExpect(
+                        MockMvcResultMatchers.jsonPath("$.slots[0]").value(
+                                Matchers.not(MockMvcResultMatchers.jsonPath("$.slots[2]"))
+                        )
+                ).andExpect(
+                        MockMvcResultMatchers.jsonPath("$.slots[1]").value(
+                                Matchers.not(MockMvcResultMatchers.jsonPath("$.slots[2]"))
+                        )
                 )
                 .andReturn();
     }

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerParkingPostMethodErrorsIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerParkingPostMethodErrorsIntegrationTest.java
@@ -3,6 +3,7 @@ package assessment.parkinglot.integration.controller;
 import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.controller.model.ParkingRequest;
 import assessment.parkinglot.errors.DataDuplication;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.peristence.repositories.SpotRepository;
 import assessment.parkinglot.peristence.repositories.SpotTypeRepository;
 import assessment.parkinglot.services.PersistenceService;
@@ -23,9 +24,10 @@ public class LotControllerParkingPostMethodErrorsIntegrationTest
     @Autowired
     public LotControllerParkingPostMethodErrorsIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , PersistenceService persistenceService, SpotRepository spotRepository, SpotTypeRepository spotTypeRepository, EntityManager entityManager
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService , LotController.class);
         this.persistenceService = persistenceService;
         this.spotRepository = spotRepository;
         this.spotTypeRepository = spotTypeRepository;

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerTakenSpotsErrorsIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerTakenSpotsErrorsIntegrationTest.java
@@ -1,9 +1,9 @@
 package assessment.parkinglot.integration.controller;
 
 import assessment.parkinglot.controller.LotController;
-import assessment.parkinglot.controller.model.SpotTypeStatusResponse;
 import assessment.parkinglot.errors.DataDuplication;
 import assessment.parkinglot.errors.DataNotFound;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.peristence.repositories.SpotRepository;
 import assessment.parkinglot.services.PersistenceService;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,9 +25,10 @@ public class LotControllerTakenSpotsErrorsIntegrationTest
     @Autowired
     public LotControllerTakenSpotsErrorsIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , PersistenceService persistenceService, SpotRepository spotRepository
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService, LotController.class);
         this.persistenceService = persistenceService;
         this.spotRepository = spotRepository;
     }

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerTakenSpotsHappyPathIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerTakenSpotsHappyPathIntegrationTest.java
@@ -4,6 +4,7 @@ import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.controller.model.SpotTypeStatusResponse;
 import assessment.parkinglot.errors.DataDuplication;
 import assessment.parkinglot.errors.DataNotFound;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.peristence.repositories.SpotRepository;
 import assessment.parkinglot.services.PersistenceService;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,9 +26,10 @@ public class LotControllerTakenSpotsHappyPathIntegrationTest
     @Autowired
     public LotControllerTakenSpotsHappyPathIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , PersistenceService persistenceService, SpotRepository spotRepository
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService, LotController.class);
         this.persistenceService = persistenceService;
         this.spotRepository = spotRepository;
     }

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerVerifyingErrorIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerVerifyingErrorIntegrationTest.java
@@ -2,9 +2,8 @@ package assessment.parkinglot.integration.controller;
 
 import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.errors.DataDuplication;
-import assessment.parkinglot.errors.DataNotFound;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.services.PersistenceService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -21,9 +20,10 @@ public class LotControllerVerifyingErrorIntegrationTest
     @Autowired
     public LotControllerVerifyingErrorIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , PersistenceService persistenceService
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService, LotController.class);
         this.persistenceService = persistenceService;
     }
 

--- a/src/test/java/assessment/parkinglot/integration/controller/LotControllerVerifyingHappyPathIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/controller/LotControllerVerifyingHappyPathIntegrationTest.java
@@ -4,6 +4,7 @@ import assessment.parkinglot.controller.LotController;
 import assessment.parkinglot.errors.DataDuplication;
 import assessment.parkinglot.errors.DataNotFound;
 import assessment.parkinglot.controller.model.SpotTypeStatusResponse;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.services.PersistenceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,9 +23,10 @@ public class LotControllerVerifyingHappyPathIntegrationTest
     @Autowired
     public LotControllerVerifyingHappyPathIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , PersistenceService persistenceService
     ) {
-        super(webApplicationContext, LotController.class);
+        super(webApplicationContext, persistenceCleanerService, LotController.class);
         this.persistenceService = persistenceService;
     }
 

--- a/src/test/java/assessment/parkinglot/integration/service/ConfigurationServiceErrorIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/service/ConfigurationServiceErrorIntegrationTest.java
@@ -6,6 +6,7 @@ import assessment.parkinglot.errors.DataDuplication;
 import assessment.parkinglot.errors.DataNotFound;
 import assessment.parkinglot.integration.BasicIntegrationTest;
 import assessment.parkinglot.services.ConfigurationService;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.context.WebApplicationContext;
@@ -22,8 +23,9 @@ public class ConfigurationServiceErrorIntegrationTest
     @Autowired
     public ConfigurationServiceErrorIntegrationTest(
             WebApplicationContext webApplicationContext, ConfigurationService configurationService
+            , PersistenceCleanerService persistenceCleanerService
     ) {
-        super(webApplicationContext);
+        super(webApplicationContext, persistenceCleanerService);
         this.configurationService = configurationService;
     }
 

--- a/src/test/java/assessment/parkinglot/integration/service/PersistenceServiceErrorIntegrationTest.java
+++ b/src/test/java/assessment/parkinglot/integration/service/PersistenceServiceErrorIntegrationTest.java
@@ -3,6 +3,7 @@ package assessment.parkinglot.integration.service;
 import assessment.parkinglot.errors.DataDuplication;
 import assessment.parkinglot.errors.DataNotFound;
 import assessment.parkinglot.integration.BasicIntegrationTest;
+import assessment.parkinglot.config.components.PersistenceCleanerService;
 import assessment.parkinglot.services.PersistenceService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,9 +19,10 @@ public class PersistenceServiceErrorIntegrationTest
     @Autowired
     public PersistenceServiceErrorIntegrationTest(
             WebApplicationContext webApplicationContext
+            , PersistenceCleanerService persistenceCleanerService
             , PersistenceService persistenceService
     ) {
-        super(webApplicationContext);
+        super(webApplicationContext, persistenceCleanerService);
         this.persistenceService = persistenceService;
     }
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,3 +1,9 @@
+spring.main.lazy-initialization=true
+logging.level.org.springframework.test.context.cache=DEBUG
+spring.test.context.cache.maxSize=10
+
+#spring.jpa.hibernate.ddl-auto=validate
+
 lot.mappings[0].vehicleType=carTest
 lot.mappings[0].spotType=regularTest
 lot.mappings[0].required-slots=1


### PR DESCRIPTION
Add 2 test optimizations strategies for db persistence. Truncation and Repository deleteAll. Simple switch added on TestConfiguration file. 